### PR TITLE
Add automated API test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && esbuild server/fullTextExtractor.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/fullTextExtractor.js",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test:api": "node ./scripts/test-api.mjs"
   },
   "dependencies": {
     "@google-cloud/text-to-speech": "^6.1.0",

--- a/scripts/test-api.mjs
+++ b/scripts/test-api.mjs
@@ -1,0 +1,50 @@
+import { spawn } from 'child_process';
+import fetch from 'node-fetch';
+import { setTimeout as wait } from 'timers/promises';
+
+async function run(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: 'inherit', ...opts });
+    child.on('close', code => {
+      code === 0 ? resolve() : reject(new Error(`${cmd} exited with code ${code}`));
+    });
+  });
+}
+
+async function waitFor(url, timeout = 10000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {}
+    await wait(500);
+  }
+  throw new Error(`Timeout waiting for ${url}`);
+}
+
+async function main() {
+  await run('npm', ['run', 'build']);
+
+  const port = process.env.TEST_PORT || '3333';
+  const server = spawn('node', ['dist/index.js'], {
+    env: { ...process.env, PORT: port, GEMINI_API_KEY: 'dummy-key' },
+    stdio: 'inherit'
+  });
+
+  try {
+    await waitFor(`http://localhost:${port}/health`);
+    const health = await fetch(`http://localhost:${port}/health`);
+    console.log('Health status:', health.status);
+
+    const sefaria = await fetch(`http://localhost:${port}/api/sefaria/texts/Likutei_Moharan.1`);
+    console.log('Sefaria status:', sefaria.status);
+  } finally {
+    server.kill();
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -372,6 +372,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Basic health check for automated tests
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
   const httpServer = createServer(app);
 
   return httpServer;


### PR DESCRIPTION
## Summary
- add simple `/health` route for testing
- build server helper script for `fullTextExtractor`
- add `test:api` script and test runner

## Testing
- `npm run test:api`

------
https://chatgpt.com/codex/tasks/task_e_6862a617f0c48320a64e96da45fdd822