### PR TITLE
Add health check route

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,9 @@ const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
+// Simple health check route
+app.get('/health', (_req, res) => res.send('ok'));
+
 app.use((req, res, next) => {
   const start = Date.now();
   const path = req.path;


### PR DESCRIPTION
## Summary
- expose a simple `/health` endpoint
- keep express listening on `process.env.PORT` with fallback

## Testing
- `npm run check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6862a616d9b48320a57815fad83dd56c