### PR TITLE
Add gemini block helper

### DIFF
--- a/client/src/services/gemini.ts
+++ b/client/src/services/gemini.ts
@@ -1,6 +1,57 @@
 
 // Service Gemini utilisant le proxy serveur
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
 class GeminiService {
+  private directModel: ReturnType<GoogleGenerativeAI['getGenerativeModel']> | null = null;
+
+  private ensureModel() {
+    if (!this.directModel) {
+      const apiKey = (import.meta as any).env.VITE_GEMINI_API_KEY;
+      if (!apiKey) throw new Error('GEMINI_API_KEY missing');
+      const ai = new GoogleGenerativeAI(apiKey);
+      this.directModel = ai.getGenerativeModel({ model: 'gemini-1.5-flash-latest' });
+    }
+  }
+
+  private splitIntoBlocks(text: string, maxLen = 1600) {
+    const sentences = text.match(/[^.!?]+[.!?]+[\])'"`’”]*|.+/g) || [text];
+    const blocks: string[] = [];
+    let current = '';
+    for (const sentence of sentences) {
+      if ((current + sentence).length > maxLen) {
+        if (current.trim()) blocks.push(current.trim());
+        current = sentence;
+      } else {
+        current += sentence;
+      }
+    }
+    if (current.trim()) blocks.push(current.trim());
+    return blocks;
+  }
+
+  private levenshtein(a: string, b: string) {
+    const matrix: number[][] = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0));
+    for (let i = 0; i <= a.length; i++) matrix[i][0] = i;
+    for (let j = 0; j <= b.length; j++) matrix[0][j] = j;
+    for (let i = 1; i <= a.length; i++) {
+      for (let j = 1; j <= b.length; j++) {
+        const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + cost
+        );
+      }
+    }
+    return matrix[a.length][b.length];
+  }
+
+  private similarity(a: string, b: string) {
+    const dist = this.levenshtein(a, b);
+    const max = Math.max(a.length, b.length) || 1;
+    return 1 - dist / max;
+  }
   async generateContentStream({
     prompt,
     onChunk,
@@ -130,6 +181,26 @@ class GeminiService {
       provider: 'Google AI',
       capabilities: ['text-generation', 'streaming', 'multilingual']
     };
+  }
+
+  async sendInBlocks(text: string): Promise<string[]> {
+    this.ensureModel();
+    const blocks = this.splitIntoBlocks(text, 1600);
+    const chat = this.directModel!.startChat();
+    const replies: string[] = [];
+    const history: string[] = [];
+
+    for (const block of blocks) {
+      const isDup = history.some((prev) => this.similarity(prev, block) > 0.8);
+      if (isDup) continue;
+      history.push(block);
+      const result = await chat.sendMessage(block, {
+        generationConfig: { maxOutputTokens: 256 }
+      });
+      replies.push(result.response.text());
+    }
+
+    return replies;
   }
 }
 


### PR DESCRIPTION
## Summary
- add Gemini block splitting helper that keeps one chat session
- detect duplicates by similarity and cap token output

## Testing
- `npm run check` *(fails: cannot find names in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6862a61552008320b3fdafcbe1225188