### PR TITLE
Add Google TTS credentials decoding and switch to v1beta1

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,9 +3,26 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { extractCompleteBook } from "./fullTextExtractor";
 import { cacheService } from "./cache";
+import fs from "fs";
+import path from "path";
 
 // Set environment variables for frontend
 process.env.VITE_GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+
+// Decode Google TTS credentials if provided
+if (process.env.GOOGLE_TTS_CREDENTIALS_B64) {
+  try {
+    const credentialsPath = path.join(process.cwd(), 'serviceAccount.json');
+    fs.writeFileSync(
+      credentialsPath,
+      Buffer.from(process.env.GOOGLE_TTS_CREDENTIALS_B64, 'base64')
+    );
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = credentialsPath;
+    console.log(`[TTS-Cloud] Credentials written to ${credentialsPath}`);
+  } catch (err) {
+    console.error('[TTS-Cloud] Failed to decode credentials', err);
+  }
+}
 
 const app = express();
 app.use(express.json());


### PR DESCRIPTION
## Summary
- decode `$GOOGLE_TTS_CREDENTIALS_B64` to `serviceAccount.json` on startup
- initialize TextToSpeechClient from that file using v1beta1 API
- update TTS synthesize request types

## Testing
- `npm run check` *(fails: Cannot find names and other TS errors)*
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862a61309d48320afaf53c2a6af7118