### PR TITLE
Add better sqlite3 types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.1.3",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/connect-pg-simple": "^7.0.3",
         "@types/express": "4.17.21",
         "@types/express-session": "^1.18.0",
@@ -3484,6 +3485,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/connect-pg-simple": "^7.0.3",
     "@types/express": "4.17.21",
     "@types/express-session": "^1.18.0",


### PR DESCRIPTION
## Summary
- install `@types/better-sqlite3` as a dev dependency

## Testing
- `npm run check` *(fails: cannot find names and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862ae258e908320837e6fdac6ff4051