### PR TITLE
Fix cast for webkitTapHighlightColor

### DIFF
--- a/client/src/services/mobileOptimized.ts
+++ b/client/src/services/mobileOptimized.ts
@@ -233,7 +233,7 @@ export const MobileUtils = {
     
     document.body.style.touchAction = 'manipulation';
     document.body.style.webkitTextSizeAdjust = '100%';
-    document.body.style.webkitTapHighlightColor = 'transparent';
+    (document.body.style as any).webkitTapHighlightColor = 'transparent';
   },
 
   preventZoom(): void {


### PR DESCRIPTION
## Summary
- fix typing for webkitTapHighlightColor in `MobileUtils`

## Testing
- `npx tsc --noEmit client/src/services/mobileOptimized.ts`

------
https://chatgpt.com/codex/tasks/task_e_6862ae2433f88320aad3734b21f3b834