### PR TITLE
Fix allowedHosts in Vite server config

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -23,7 +23,8 @@ export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    // allow all hosts in dev mode
+    allowedHosts: "all" as unknown as true,
   };
 
   const vite = await createViteServer({


### PR DESCRIPTION
## Summary
- configure Vite dev server to allow all hosts

## Testing
- `npm run check` *(fails: Cannot find name 'sefariaService', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6862ae22853483208dfec56da4e09a6a