### PR TITLE
Fix user creation type

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -30,7 +30,7 @@ export class MemStorage implements IStorage {
 
   async createUser(insertUser: InsertUser): Promise<User> {
     const id = this.currentId++;
-    const user: User = { ...insertUser, id };
+    const user: User = { ...insertUser, id, createdAt: new Date() };
     this.users.set(id, user);
     return user;
   }


### PR DESCRIPTION
## Summary
- populate the `createdAt` field when creating a user

## Testing
- `npm run check` *(fails: Cannot find name 'sefariaService' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862ae1fe7b08320b63743e00c259807