### PR TITLE
Fix .replit deployment run command

### DIFF
--- a/.replit
+++ b/.replit
@@ -23,7 +23,7 @@ externalPort = 80
 
 [deployment]
 build = ["npm", "run", "build"]
-run = ["npm", "start"]
+run = ["npm", "run", "start"]
 
 [workflows]
 runButton = "Start Application"


### PR DESCRIPTION
## Summary
- update `.replit` to run `npm run start` for deployment

## Testing
- `npx vitest run`
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_686a5af8a774832090f8040c15588ee6