### PR TITLE
Fix scripts path handling

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # Simple startup script
 export PATH="/nix/store/dj805sw07vvpbxx39c8g67x8qddg0ikw-nodejs-18.12.1/bin:$PATH"
-cd /home/runner/workspace
+cd "$(dirname "$0")"
 exec npx tsx server/index.ts

--- a/start.sh
+++ b/start.sh
@@ -10,5 +10,5 @@ pkill -f "tsx server/index.ts" 2>/dev/null || true
 sleep 2
 
 # Démarrer le serveur
-cd /home/runner/workspace
+cd "$(dirname "$0")"
 PORT=5000 NODE_ENV=development tsx server/index.ts


### PR DESCRIPTION
## Summary
- use relative path in `run.sh` and `start.sh`
- ensure both scripts end with newlines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a601dc7448320b689d577608cd381