### PR TITLE
Fix CI workflow commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
       - run: npm ci
-      - run: npm run test:unit
+      - run: npx vitest run
   e2e:
     needs: unit
     runs-on: ubuntu-latest
@@ -17,4 +17,5 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: 20 }
       - run: npm ci
+      - run: npx playwright install --with-deps
       - run: npm run test:e2e || echo "E2E optional for now"


### PR DESCRIPTION
## Summary
- fix unit test command in CI
- install Playwright browsers for e2e job

## Testing
- `npx vitest run`
- `npm run test:e2e` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a610f91948320b00165c903430c91